### PR TITLE
Batch editing replays in parallel

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ This is the lite version of Bob.
 
 - Double-click the BobLite jar file. That will open the Project Selector
 - Create a new project, select it and click `Open Project`
+- Choose one or more replay files to edit.
 - After that, it should be pretty straight forward. The time is in ticks, like the `/time set` command
 - Finally, a new file chooser will appear. Select your drive with the most storage space. That will be where the temporary file will be created.
 

--- a/src/main/java/fr/rader/boblite/EditReplayTask.java
+++ b/src/main/java/fr/rader/boblite/EditReplayTask.java
@@ -20,9 +20,15 @@ public class EditReplayTask implements Runnable {
     private final boolean removeRain;
 
     public EditReplayTask(ReplayData replayData, File tempFileDirectory, Menu menu) throws NullPointerException {
-        if(replayData == null) throw new NullPointerException("replayData is null");
-        if(tempFileDirectory == null) throw new NullPointerException("tempFileDirectory is null");
-        if(menu == null) throw new NullPointerException("menu is null");
+        if(replayData == null){
+            throw new NullPointerException("replayData is null");
+        }
+        if(tempFileDirectory == null){
+            throw new NullPointerException("tempFileDirectory is null");
+        }
+        if(menu == null){
+            throw new NullPointerException("menu is null");
+        }
 
         this.replayData = replayData;
         this.tempFileDirectory = tempFileDirectory;

--- a/src/main/java/fr/rader/boblite/EditReplayTask.java
+++ b/src/main/java/fr/rader/boblite/EditReplayTask.java
@@ -20,15 +20,15 @@ public class EditReplayTask implements Runnable {
     private final boolean removeRain;
 
     public EditReplayTask(ReplayData replayData, File tempFileDirectory, Menu menu) throws NullPointerException {
-        if(replayData == null) {
+        if (replayData == null) {
             throw new NullPointerException("replayData is null");
         }
 
-        if(tempFileDirectory == null) {
+        if (tempFileDirectory == null) {
             throw new NullPointerException("tempFileDirectory is null");
         }
 
-        if(menu == null) {
+        if (menu == null) {
             throw new NullPointerException("menu is null");
         }
 

--- a/src/main/java/fr/rader/boblite/EditReplayTask.java
+++ b/src/main/java/fr/rader/boblite/EditReplayTask.java
@@ -42,11 +42,14 @@ public class EditReplayTask implements Runnable {
 
     @Override
     public void run() {
-        // here, we get the correct packet id depending on the protocol version
+        // we get the minecraft version from the replay's metadata
+        String minecraftVersion = (String) replayData.getMetaData("mcversion");
+
+        // here, we get the correct packet id depending on the minecraft version
         int timePacketID;
         int weatherPacketID;
         int chatPacketID;
-        switch ((String) replayData.getMetaData("mcversion")) {
+        switch (minecraftVersion) {
             case "1.8":
             case "1.8.1":
             case "1.8.2":
@@ -131,7 +134,7 @@ public class EditReplayTask implements Runnable {
 
             // we show an error and stop if the protocol isn't supported
             default:
-                JOptionPane.showMessageDialog(null, "Error: unsupported Minecraft version: " + replayData.getMetaData("mcversion"));
+                JOptionPane.showMessageDialog(null, "Error: unsupported Minecraft version: " + minecraftVersion);
                 return;
         }
 

--- a/src/main/java/fr/rader/boblite/EditReplayTask.java
+++ b/src/main/java/fr/rader/boblite/EditReplayTask.java
@@ -20,13 +20,15 @@ public class EditReplayTask implements Runnable {
     private final boolean removeRain;
 
     public EditReplayTask(ReplayData replayData, File tempFileDirectory, Menu menu) throws NullPointerException {
-        if(replayData == null){
+        if(replayData == null) {
             throw new NullPointerException("replayData is null");
         }
-        if(tempFileDirectory == null){
+
+        if(tempFileDirectory == null) {
             throw new NullPointerException("tempFileDirectory is null");
         }
-        if(menu == null){
+
+        if(menu == null) {
             throw new NullPointerException("menu is null");
         }
 
@@ -37,8 +39,6 @@ public class EditReplayTask implements Runnable {
         this.newTime = menu.getNewTime();
         this.removeRain = menu.isRemoveRainChecked();
     }
-
-
 
     @Override
     public void run() {
@@ -249,7 +249,6 @@ public class EditReplayTask implements Runnable {
 
             // kill the progress bar window as it's now useless
             progressBar.kill();
-
         } catch (IOException e) {
             e.printStackTrace();
         }

--- a/src/main/java/fr/rader/boblite/EditReplayTask.java
+++ b/src/main/java/fr/rader/boblite/EditReplayTask.java
@@ -1,0 +1,251 @@
+package fr.rader.boblite;
+
+import fr.rader.boblite.guis.Menu;
+import fr.rader.boblite.guis.ProgressBar;
+import fr.rader.boblite.utils.DataReader;
+import fr.rader.boblite.utils.DataWriter;
+import fr.rader.boblite.utils.ReplayZip;
+
+import javax.swing.*;
+import java.io.File;
+import java.io.IOException;
+
+public class EditReplayTask implements Runnable {
+
+    private final ReplayData replayData;
+    private final File tempFileDirectory;
+    private final boolean removeChat;
+    private final boolean changeTime;
+    private final int newTime;
+    private final boolean removeRain;
+
+    public EditReplayTask(ReplayData replayData, File tempFileDirectory, Menu menu) throws NullPointerException {
+        if(replayData == null) throw new NullPointerException("replayData is null");
+        if(tempFileDirectory == null) throw new NullPointerException("tempFileDirectory is null");
+        if(menu == null) throw new NullPointerException("menu is null");
+
+        this.replayData = replayData;
+        this.tempFileDirectory = tempFileDirectory;
+        this.removeChat = menu.isRemoveChatChecked();
+        this.changeTime = menu.isChangeTimeChecked();
+        this.newTime = menu.getNewTime();
+        this.removeRain = menu.isRemoveRainChecked();
+    }
+
+
+
+    @Override
+    public void run() {
+        // here, we get the correct packet id depending on the protocol version
+        int timePacketID;
+        int weatherPacketID;
+        int chatPacketID;
+        switch ((String) replayData.getMetaData("mcversion")) {
+            case "1.8":
+            case "1.8.1":
+            case "1.8.2":
+            case "1.8.3":
+            case "1.8.4":
+            case "1.8.5":
+            case "1.8.6":
+            case "1.8.7":
+            case "1.8.8":
+            case "1.8.9":
+                timePacketID = 0x03;
+                weatherPacketID = 0x2B;
+                chatPacketID = 0x02;
+                break;
+
+            case "1.9":
+            case "1.9.1":
+            case "1.9.2":
+            case "1.9.3":
+            case "1.9.4":
+            case "1.10":
+            case "1.10.1":
+            case "1.10.2":
+            case "1.11":
+            case "1.11.1":
+            case "1.11.2":
+                timePacketID = 0x44;
+                weatherPacketID = 0x1E;
+                chatPacketID = 0x0F;
+                break;
+
+            case "1.12":
+            case "1.12.1":
+            case "1.12.2":
+                timePacketID = 0x47;
+                weatherPacketID = 0x1E;
+                chatPacketID = 0x0F;
+                break;
+
+            case "1.14":
+            case "1.14.1":
+            case "1.14.2":
+            case "1.14.3":
+            case "1.14.4":
+                timePacketID = 0x4E;
+                weatherPacketID = 0x1E;
+                chatPacketID = 0x0E;
+                break;
+
+            case "1.15":
+            case "1.15.1":
+            case "1.15.2":
+                timePacketID = 0x4F;
+                weatherPacketID = 0x1F;
+                chatPacketID = 0x0F;
+                break;
+
+            case "1.16":
+            case "1.16.1":
+            case "1.16.2":
+            case "1.16.3":
+            case "1.16.4":
+            case "1.16.5":
+                timePacketID = 0x4E;
+                weatherPacketID = 0x1D;
+                chatPacketID = 0x0E;
+                break;
+
+            case "1.17":
+            case "1.17.1":
+                timePacketID = 0x58;
+                weatherPacketID = 0x1E;
+                chatPacketID = 0x0F;
+                break;
+
+            case "1.18":
+            case "1.18.1":
+                timePacketID = 0x59;
+                weatherPacketID = 0x1E;
+                chatPacketID = 0x0F;
+                break;
+
+            // we show an error and stop if the protocol isn't supported
+            default:
+                JOptionPane.showMessageDialog(null, "Error: unsupported Minecraft version: " + replayData.getMetaData("mcversion"));
+                return;
+        }
+
+        try {
+            // get the mcpr file as a zip file
+            ReplayZip replayZip = replayData.getReplayZip();
+            // we open the recording.tmcpr file in a data reader
+            DataReader reader = new DataReader(replayZip.getEntry("recording.tmcpr"));
+            // we also create a data writer to write the modified packets
+            // or any packets that we don't want to edit
+            DataWriter writer = new DataWriter(this.tempFileDirectory);
+
+            writer.writeInt(reader.readInt());
+            int length = reader.readInt();
+            writer.writeInt(length);
+            writer.writeByteArray(reader.readFollowingBytes(length));
+
+            // getting the replay duration for the progress bar
+            Double duration = (Double) replayData.getMetaData("duration");
+            // creating the progress bar and setting the action text
+            ProgressBar progressBar = new ProgressBar(duration.intValue());
+            progressBar.setActionText("Editing the replay...");
+            // showing the progress bar
+            progressBar.show();
+
+            // iterate while we still have some data in the reader
+            while (reader.getLength() != 0) {
+                // get the timestamp, the size and the packet id
+                int timestamp = reader.readInt();
+                int size = reader.readInt();
+                int packetID = reader.readVarInt();
+
+                // changing the progress bar value
+                progressBar.setProgressBarValue(timestamp);
+
+                // check if the packet id is a chat message packet,
+                // and if the removeChat checkbox is checked
+                if (this.removeChat && packetID == chatPacketID) {
+                    // if bob has to remove the chat packet,
+                    // we skip it, and we don't write it
+                    reader.skip(size - 1);
+                    continue;
+                }
+
+                // check if the packet id is a time packet,
+                // and if the changeTime checkbox is checked
+                if (this.changeTime && packetID == timePacketID) {
+                    // writing packet header
+                    writer.writeInt(timestamp);
+                    writer.writeInt(size);
+                    writer.writeVarInt(packetID);
+
+                    // writing world age
+                    writer.writeLong(reader.readLong());
+                    // writing new time
+                    writer.writeLong(this.newTime);
+
+                    // skip the next 8 bytes (old world time)
+                    reader.skip(8);
+
+                    continue;
+                }
+
+                // check if the packet id is a weather packet,
+                // and if the removeRain checkbox is checked
+                if (this.removeRain && packetID == weatherPacketID) {
+                    // get the reason, we don't want to ignore it because
+                    // this packet isn't always used for the weather
+                    int reason = reader.readByte();
+
+                    // reason == 1 -> end raining
+                    // reason == 2 -> begin raining
+                    // reason == 7 -> rain level change
+                    // reason == 8 -> thunder level change
+                    // iirc reason 1 and 2 are swapped
+                    if (reason != 1 && reason != 2 && reason != 7 && reason != 8) {
+                        // if the packet does not change the rain, we write it
+                        // packet header
+                        writer.writeInt(timestamp);
+                        writer.writeInt(size);
+                        writer.writeVarInt(packetID);
+
+                        // packet content
+                        writer.writeByte(reason);
+                        writer.writeFloat(reader.readFloat());
+                    } else {
+                        // we skip the next 4 bytes (new rain/thunder level)
+                        reader.skip(4);
+                    }
+
+                    continue;
+                }
+
+                // we write the packet timestamp, size, packet id
+                writer.writeInt(timestamp);
+                writer.writeInt(size);
+                writer.writeVarInt(packetID);
+                // and finally, we write the packet data
+                writer.writeByteArray(reader.readFollowingBytes(size - 1));
+            }
+
+            // we then flush the writer
+            writer.flush();
+
+            // changing the progress bar action text,
+            // as we're now doing something else
+            progressBar.setActionText("Writing the replay, this can take a while...");
+
+            // we open the zip file, write the recording.tmcpr file and close the zip
+            replayZip.open();
+            replayZip.addFile(writer.getInputStream(), "recording.tmcpr");
+            replayZip.close();
+
+            writer.clear();
+
+            // kill the progress bar window as it's now useless
+            progressBar.kill();
+
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
+    }
+}

--- a/src/main/java/fr/rader/boblite/Main.java
+++ b/src/main/java/fr/rader/boblite/Main.java
@@ -155,7 +155,7 @@ public class Main {
         }
 
         long finishTime = System.currentTimeMillis();
-        System.out.println("Competed " + replays.size() + " task(s) in " + (int)(((finishTime - startTime) / 1000) / 60) + "m " + (int)(((finishTime - startTime) / 1000) % 60) + "s");
+        System.out.println("Completed " + replays.size() + " task(s) in " + (int)(((finishTime - startTime) / 1000) / 60) + "m " + (int)(((finishTime - startTime) / 1000) % 60) + "s");
         System.out.println("File(s) located at " + projectFolder.getAbsolutePath().toString());
 
         // Open the file explorer where the replay(s) are saved.

--- a/src/main/java/fr/rader/boblite/Main.java
+++ b/src/main/java/fr/rader/boblite/Main.java
@@ -151,6 +151,7 @@ public class Main {
             System.out.println("Interrupted while waiting for all tasks to complete.");
             executor.shutdownNow();
             exception.printStackTrace();
+            JOptionPane.showMessageDialog(null,  "Error:\nInterrupted while waiting for all tasks to complete.");
             System.exit(0);
         }
 

--- a/src/main/java/fr/rader/boblite/Main.java
+++ b/src/main/java/fr/rader/boblite/Main.java
@@ -118,7 +118,7 @@ public class Main {
 
         System.out.println("Using " + executorThreadNumber + " thread(s) for " + replays.size() + " task(s)...");
 
-        ExecutorService executor = Executors.newFixedThreadPool(totalSystemThreadNumber);
+        ExecutorService executor = Executors.newFixedThreadPool(executorThreadNumber);
 
         long startTime = System.currentTimeMillis();
 

--- a/src/main/java/fr/rader/boblite/Main.java
+++ b/src/main/java/fr/rader/boblite/Main.java
@@ -52,9 +52,9 @@ public class Main {
             if (file.getName().endsWith(".mcpr") && !file.isDirectory()) {
                 replays.add(
                         new ReplayData(
-                        file,
-                        projectFolder,
-                        this
+                            file,
+                            projectFolder,
+                            this
                         )
                 );
             }
@@ -74,14 +74,14 @@ public class Main {
                             Files.copy(file.toPath(), newFile.toPath());
                             replays.add(
                                     new ReplayData(
-                                    file,
-                                    projectFolder,
-                                    this
+                                        file,
+                                        projectFolder,
+                                        this
                                     )
                             );
                         } catch (IOException exception) {
                             // If there is a problem, just stop.
-                            System.out.println("Failed to copy file from " + file.getAbsolutePath().toString() + " to " + newFile.getAbsolutePath().toString());
+                            System.out.println("Failed to copy file from " + file.getAbsolutePath() + " to " + newFile.getAbsolutePath());
                             System.exit(0);
                         }
                     }
@@ -137,9 +137,9 @@ public class Main {
         for (ReplayData replay : replays){
             executor.submit(
                     new EditReplayTask(
-                    replay,
-                    tempFileDirectory,
-                    menu
+                        replay,
+                        tempFileDirectory,
+                        menu
                     )
             );
         }
@@ -158,10 +158,9 @@ public class Main {
             System.exit(0);
         }
 
-
-        long finishTime = System.currentTimeMillis();
-        System.out.println("Completed " + replays.size() + " task(s) in " + (int)(((finishTime - startTime) / 1000) / 60) + "m " + (int)(((finishTime - startTime) / 1000) % 60) + "s");
-        System.out.println("File(s) located at " + projectFolder.getAbsolutePath().toString());
+        long totalTime = (System.currentTimeMillis() - startTime) / 1000;
+        System.out.println("Completed " + replays.size() + " task(s) in " + (totalTime / 60) + "m " + (totalTime % 60) + "s");
+        System.out.println("File(s) located at " + projectFolder.getAbsolutePath());
 
         // Open the file explorer where the replay(s) are saved.
         IO.openFileExplorer(projectFolder);

--- a/src/main/java/fr/rader/boblite/Main.java
+++ b/src/main/java/fr/rader/boblite/Main.java
@@ -50,16 +50,20 @@ public class Main {
         List<ReplayData> replays = new ArrayList<ReplayData>();
         for (File file : projectFiles) {
             if (file.getName().endsWith(".mcpr") && !file.isDirectory()) {
-                replays.add(new ReplayData(
+                replays.add(
+                        new ReplayData(
                         file,
                         projectFolder,
-                        this));
+                        this)
+                );
             }
         }
 
         // If no .mcpr files existed in the project folder, ask the user to select one or more .mcpr files.
-        if(replays.isEmpty()){
+        if(replays.isEmpty()) {
+
             File[] files = IO.openFilePrompt(OS.getMinecraftFolder() + "replay_recordings/", "Replay File", "mcpr");
+
             if(files != null) {
                 for (File file : files) {
                     // It should be impossible for non .mcpr files to be returned, but I feel like wasting a few more CPU cycles just to be safe.
@@ -67,10 +71,12 @@ public class Main {
                         File newFile = new File(projectFolder.getAbsolutePath() + "/" + file.getName());
                         try {
                             Files.copy(file.toPath(), newFile.toPath());
-                            replays.add(new ReplayData(
+                            replays.add(
+                                    new ReplayData(
                                     file,
                                     projectFolder,
-                                    this));
+                                    this)
+                            );
                         } catch (IOException exception) {
                             // If there is a problem, just stop.
                             System.out.println("Failed to copy file from " + file.getAbsolutePath().toString() + " to " + newFile.getAbsolutePath().toString());
@@ -80,7 +86,7 @@ public class Main {
                 }
             }
             // If the user didn't select any files, exit.
-            if(replays.isEmpty()){
+            if(replays.isEmpty()) {
                 System.out.println("No Replays selected, stopping.");
                 System.exit(0);
             }
@@ -108,13 +114,15 @@ public class Main {
         // Get the total number of system CPU threads.
         int totalSystemThreadNumber = Runtime.getRuntime().availableProcessors();
         int executorThreadNumber;
-        if (replays.size() < totalSystemThreadNumber){
+        if (replays.size() < totalSystemThreadNumber) {
             executorThreadNumber = replays.size();
-        }else{
+        } else {
             // Leave at least one system thread idle, don't make the computer unusable.
             executorThreadNumber = totalSystemThreadNumber - 1;
             // If for whatever reason the computer only has one CPU core/thread, just use one thread.
-            if(executorThreadNumber < 1) executorThreadNumber = 1;
+            if(executorThreadNumber < 1) {
+                executorThreadNumber = 1;
+            }
         }
 
         System.out.println("Using " + executorThreadNumber + " thread(s) for " + replays.size() + " task(s)...");
@@ -125,21 +133,25 @@ public class Main {
 
         // Submit all tasks.
         for(ReplayData replay : replays){
-            executor.submit(new EditReplayTask(
+            executor.submit(
+                    new EditReplayTask(
                     replay,
                     tempFileDirectory,
-                    menu));
+                    menu)
+            );
         }
 
         // Wait for all task to be completed.
         executor.shutdown();
+
         boolean isDone = false;
+
         while(!isDone) {
+
             try {
                 // Timeout doesn't really matter in this use case as we will want to wait for all tasks to complete before terminating.
                 isDone = executor.awaitTermination(7, TimeUnit.DAYS);
-            } catch (InterruptedException ex) {
-            }
+            } catch (InterruptedException ex) { }
         }
 
         long finishTime = System.currentTimeMillis();

--- a/src/main/java/fr/rader/boblite/Main.java
+++ b/src/main/java/fr/rader/boblite/Main.java
@@ -1,7 +1,6 @@
 package fr.rader.boblite;
 
 import fr.rader.boblite.guis.Menu;
-import fr.rader.boblite.guis.ProgressBar;
 import fr.rader.boblite.guis.ProjectSelector;
 import fr.rader.boblite.utils.*;
 
@@ -9,12 +8,19 @@ import javax.swing.*;
 import java.awt.*;
 import java.io.File;
 import java.io.IOException;
+import java.nio.file.Files;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
 
 public class Main {
 
     public static final Image BOB_LOGO = new ImageIcon(Main.class.getResource("/bob_logo.png")).getImage();
 
     private Projects projects;
+    private String projectName;
 
     public void start() {
         // get the projects list
@@ -23,242 +29,123 @@ public class Main {
         // open the project selector
         ProjectSelector selector = new ProjectSelector(projects);
         // get the project name from the selector
-        String projectName = selector.createWindow();
+        this.projectName = selector.createWindow();
 
         // we quit the program if the file is null (if we closed the window)
-        if (projectName == null) {
+        if (this.projectName == null) {
             return;
         }
 
-        // get the project file from the project name
-        File project = new File(OS.getBobFolder() + "projects/" + projectName);
+        // get the project folder from the project name
+        File projectFolder = new File(OS.getBobFolder() + "projects/" + this.projectName);
 
-        // get the replay data from the project file
-        ReplayData replayData = new ReplayData(project, this);
+        File[] projectFiles = projectFolder.listFiles();
 
-        // here, we get the correct packet id depending on the protocol version
-        int timePacketID;
-        int weatherPacketID;
-        int chatPacketID;
-        switch ((String) replayData.getMetaData("mcversion")) {
-            case "1.8":
-            case "1.8.1":
-            case "1.8.2":
-            case "1.8.3":
-            case "1.8.4":
-            case "1.8.5":
-            case "1.8.6":
-            case "1.8.7":
-            case "1.8.8":
-            case "1.8.9":
-                timePacketID = 0x03;
-                weatherPacketID = 0x2B;
-                chatPacketID = 0x02;
-                break;
+        if (projectFiles == null) {
+            System.out.println("'" + projectFolder.getAbsolutePath() + "' is not a valid path.");
+            System.exit(0);
+        }
 
-            case "1.9":
-            case "1.9.1":
-            case "1.9.2":
-            case "1.9.3":
-            case "1.9.4":
-            case "1.10":
-            case "1.10.1":
-            case "1.10.2":
-            case "1.11":
-            case "1.11.1":
-            case "1.11.2":
-                timePacketID = 0x44;
-                weatherPacketID = 0x1E;
-                chatPacketID = 0x0F;
-                break;
+        // Load .mcpr files from the project folder.
+        List<ReplayData> replays = new ArrayList<ReplayData>();
+        for (File file : projectFiles) {
+            if (file.getName().endsWith(".mcpr") && !file.isDirectory()) {
+                replays.add(new ReplayData(
+                        file,
+                        projectFolder,
+                        this));
+            }
+        }
 
-            case "1.12":
-            case "1.12.1":
-            case "1.12.2":
-                timePacketID = 0x47;
-                weatherPacketID = 0x1E;
-                chatPacketID = 0x0F;
-                break;
-
-            case "1.14":
-            case "1.14.1":
-            case "1.14.2":
-            case "1.14.3":
-            case "1.14.4":
-                timePacketID = 0x4E;
-                weatherPacketID = 0x1E;
-                chatPacketID = 0x0E;
-                break;
-
-            case "1.15":
-            case "1.15.1":
-            case "1.15.2":
-                timePacketID = 0x4F;
-                weatherPacketID = 0x1F;
-                chatPacketID = 0x0F;
-                break;
-
-            case "1.16":
-            case "1.16.1":
-            case "1.16.2":
-            case "1.16.3":
-            case "1.16.4":
-            case "1.16.5":
-                timePacketID = 0x4E;
-                weatherPacketID = 0x1D;
-                chatPacketID = 0x0E;
-                break;
-
-            case "1.17":
-            case "1.17.1":
-                timePacketID = 0x58;
-                weatherPacketID = 0x1E;
-                chatPacketID = 0x0F;
-                break;
-
-            case "1.18":
-            case "1.18.1":
-                timePacketID = 0x59;
-                weatherPacketID = 0x1E;
-                chatPacketID = 0x0F;
-                break;
-
-            // we show an error and stop if the protocol isn't supported
-            default:
-                JOptionPane.showMessageDialog(null, "Error: unsupported Minecraft version: " + replayData.getMetaData("mcversion"));
-                return;
+        // If no .mcpr files existed in the project folder, ask the user to select one or more .mcpr files.
+        if(replays.isEmpty()){
+            File[] files = IO.openFilePrompt(OS.getMinecraftFolder() + "replay_recordings/", "Replay File", "mcpr");
+            if(files != null) {
+                for (File file : files) {
+                    // It should be impossible for non .mcpr files to be returned, but I feel like wasting a few more CPU cycles just to be safe.
+                    if (file.getName().endsWith(".mcpr") && !file.isDirectory()) {
+                        File newFile = new File(projectFolder.getAbsolutePath() + "/" + file.getName());
+                        try {
+                            Files.copy(file.toPath(), newFile.toPath());
+                            replays.add(new ReplayData(
+                                    file,
+                                    projectFolder,
+                                    this));
+                        } catch (IOException exception) {
+                            // If there is a problem, just stop.
+                            System.out.println("Failed to copy file from " + file.getAbsolutePath().toString() + " to " + newFile.getAbsolutePath().toString());
+                            System.exit(0);
+                        }
+                    }
+                }
+            }
+            // If the user didn't select any files, exit.
+            if(replays.isEmpty()){
+                System.out.println("No Replays selected, stopping.");
+                System.exit(0);
+            }
         }
 
         // we then show the edit menu
         Menu menu = new Menu();
         menu.show();
-
         // if the user doesn't want to edit their replay,
         // we stop bob
         if (!menu.wasGoPressed()) {
             return;
         }
 
-        try {
-            // get the mcpr file as a zip file
-            ReplayZip replayZip = replayData.getReplayZip();
-            // we open the recording.tmcpr file in a data reader
-            DataReader reader = new DataReader(replayZip.getEntry("recording.tmcpr"));
-            // we also create a data writer to write the modified packets
-            // or any packets that we don't want to edit
-            DataWriter writer = new DataWriter(false);
+        // Ask the user where temporary file(s) should be located
+        File tempFileDirectory = IO.saveFilePrompt(null);
 
-            writer.writeInt(reader.readInt());
-            int length = reader.readInt();
-            writer.writeInt(length);
-            writer.writeByteArray(reader.readFollowingBytes(length));
-
-            // getting the replay duration for the progress bar
-            Double duration = (Double) replayData.getMetaData("duration");
-            // creating the progress bar and setting the action text
-            ProgressBar progressBar = new ProgressBar(duration.intValue());
-            progressBar.setActionText("Editing the replay...");
-            // showing the progress bar
-            progressBar.show();
-
-            // iterate while we still have some data in the reader
-            while (reader.getLength() != 0) {
-                // get the timestamp, the size and the packet id
-                int timestamp = reader.readInt();
-                int size = reader.readInt();
-                int packetID = reader.readVarInt();
-
-                // changing the progress bar value
-                progressBar.setProgressBarValue(timestamp);
-
-                // check if the packet id is a chat message packet,
-                // and if the removeChat checkbox is checked
-                if (menu.isRemoveChatChecked() && packetID == chatPacketID) {
-                    // if bob has to remove the chat packet,
-                    // we skip it, and we don't write it
-                    reader.skip(size - 1);
-                    continue;
-                }
-
-                // check if the packet id is a time packet,
-                // and if the changeTime checkbox is checked
-                if (menu.isChangeTimeChecked() && packetID == timePacketID) {
-                    // writing packet header
-                    writer.writeInt(timestamp);
-                    writer.writeInt(size);
-                    writer.writeVarInt(packetID);
-
-                    // writing world age
-                    writer.writeLong(reader.readLong());
-                    // writing new time
-                    writer.writeLong(menu.getNewTime());
-
-                    // skip the next 8 bytes (old world time)
-                    reader.skip(8);
-
-                    continue;
-                }
-
-                // check if the packet id is a weather packet,
-                // and if the removeRain checkbox is checked
-                if (menu.isRemoveRainChecked() && packetID == weatherPacketID) {
-                    // get the reason, we don't want to ignore it because
-                    // this packet isn't always used for the weather
-                    int reason = reader.readByte();
-
-                    // reason == 1 -> end raining
-                    // reason == 2 -> begin raining
-                    // reason == 7 -> rain level change
-                    // reason == 8 -> thunder level change
-                    // iirc reason 1 and 2 are swapped
-                    if (reason != 1 && reason != 2 && reason != 7 && reason != 8) {
-                        // if the packet does not change the rain, we write it
-                        // packet header
-                        writer.writeInt(timestamp);
-                        writer.writeInt(size);
-                        writer.writeVarInt(packetID);
-
-                        // packet content
-                        writer.writeByte(reason);
-                        writer.writeFloat(reader.readFloat());
-                    } else {
-                        // we skip the next 4 bytes (new rain/thunder level)
-                        reader.skip(4);
-                    }
-
-                    continue;
-                }
-
-                // we write the packet timestamp, size, packet id
-                writer.writeInt(timestamp);
-                writer.writeInt(size);
-                writer.writeVarInt(packetID);
-                // and finally, we write the packet data
-                writer.writeByteArray(reader.readFollowingBytes(size - 1));
-            }
-
-            // we then flush the writer
-            writer.flush();
-
-            // changing the progress bar action text,
-            // as we're now doing something else
-            progressBar.setActionText("Writing the replay, this can take a while...");
-
-            // we open the zip file, write the recording.tmcpr file and close the zip
-            replayZip.open();
-            replayZip.addFile(writer.getInputStream(), "recording.tmcpr");
-            replayZip.close();
-
-            writer.clear();
-
-            // kill the progress bar window as it's now useless
-            progressBar.kill();
-
-            // then open the file explorer to the folder that contains the replay
-            IO.openFileExplorer(replayData.getMcprFile().getParentFile());
-        } catch (IOException e) {
-            e.printStackTrace();
+        if (tempFileDirectory == null) {
+            System.exit(0);
         }
+
+        // Okay, time to get working!
+
+        // Get the total number of system CPU threads.
+        int totalSystemThreadNumber = Runtime.getRuntime().availableProcessors();
+        int executorThreadNumber;
+        if (replays.size() < totalSystemThreadNumber){
+            executorThreadNumber = replays.size();
+        }else{
+            // Leave at least one system thread idle, don't make the computer unusable.
+            executorThreadNumber = totalSystemThreadNumber - 1;
+            // If for whatever reason the computer only has one CPU core/thread, just use one thread.
+            if(executorThreadNumber < 1) executorThreadNumber = 1;
+        }
+
+        System.out.println("Using " + executorThreadNumber + " thread(s) for " + replays.size() + " task(s)...");
+
+        ExecutorService executor = Executors.newFixedThreadPool(totalSystemThreadNumber);
+
+        long startTime = System.currentTimeMillis();
+
+        // Submit all tasks.
+        for(ReplayData replay : replays){
+            executor.submit(new EditReplayTask(
+                    replay,
+                    tempFileDirectory,
+                    menu));
+        }
+
+        // Wait for all task to be completed.
+        executor.shutdown();
+        boolean isDone = false;
+        while(!isDone) {
+            try {
+                // Timeout doesn't really matter in this use case as we will want to wait for all tasks to complete before terminating.
+                isDone = executor.awaitTermination(7, TimeUnit.DAYS);
+            } catch (InterruptedException ex) { }
+        }
+
+        long finishTime = System.currentTimeMillis();
+        System.out.println("Competed " + replays.size() + " task(s) in " + (int)(((finishTime - startTime) / 1000) / 60) + "m " + (int)(((finishTime - startTime) / 1000) % 60) + "s");
+        System.out.println("File(s) located at " + projectFolder.getAbsolutePath().toString());
+
+        // Open the file explorer where the replay(s) are saved.
+        IO.openFileExplorer(projectFolder);
     }
 
     public static void main(String[] args) {
@@ -280,4 +167,8 @@ public class Main {
     public Projects getProjects() {
         return projects;
     }
+    public String getProjectName() {
+        return this.projectName;
+    }
+
 }

--- a/src/main/java/fr/rader/boblite/Main.java
+++ b/src/main/java/fr/rader/boblite/Main.java
@@ -54,17 +54,18 @@ public class Main {
                         new ReplayData(
                         file,
                         projectFolder,
-                        this)
+                        this
+                        )
                 );
             }
         }
 
         // If no .mcpr files existed in the project folder, ask the user to select one or more .mcpr files.
-        if(replays.isEmpty()) {
+        if (replays.isEmpty()) {
 
             File[] files = IO.openFilePrompt(OS.getMinecraftFolder() + "replay_recordings/", "Replay File", "mcpr");
 
-            if(files != null) {
+            if (files != null) {
                 for (File file : files) {
                     // It should be impossible for non .mcpr files to be returned, but I feel like wasting a few more CPU cycles just to be safe.
                     if (file.getName().endsWith(".mcpr") && !file.isDirectory()) {
@@ -75,7 +76,8 @@ public class Main {
                                     new ReplayData(
                                     file,
                                     projectFolder,
-                                    this)
+                                    this
+                                    )
                             );
                         } catch (IOException exception) {
                             // If there is a problem, just stop.
@@ -86,7 +88,7 @@ public class Main {
                 }
             }
             // If the user didn't select any files, exit.
-            if(replays.isEmpty()) {
+            if (replays.isEmpty()) {
                 System.out.println("No Replays selected, stopping.");
                 System.exit(0);
             }
@@ -120,7 +122,7 @@ public class Main {
             // Leave at least one system thread idle, don't make the computer unusable.
             executorThreadNumber = totalSystemThreadNumber - 1;
             // If for whatever reason the computer only has one CPU core/thread, just use one thread.
-            if(executorThreadNumber < 1) {
+            if (executorThreadNumber < 1) {
                 executorThreadNumber = 1;
             }
         }
@@ -132,12 +134,13 @@ public class Main {
         long startTime = System.currentTimeMillis();
 
         // Submit all tasks.
-        for(ReplayData replay : replays){
+        for (ReplayData replay : replays){
             executor.submit(
                     new EditReplayTask(
                     replay,
                     tempFileDirectory,
-                    menu)
+                    menu
+                    )
             );
         }
 

--- a/src/main/java/fr/rader/boblite/Main.java
+++ b/src/main/java/fr/rader/boblite/Main.java
@@ -143,16 +143,17 @@ public class Main {
 
         // Wait for all task to be completed.
         executor.shutdown();
-
-        boolean isDone = false;
-
-        while(!isDone) {
-
-            try {
-                // Timeout doesn't really matter in this use case as we will want to wait for all tasks to complete before terminating.
-                isDone = executor.awaitTermination(7, TimeUnit.DAYS);
-            } catch (InterruptedException ex) { }
+        try {
+            // Timeout doesn't really matter in this use case as we will want to wait for all tasks to complete before terminating.
+            executor.awaitTermination(Integer.MAX_VALUE, TimeUnit.DAYS);
+        } catch (InterruptedException exception) {
+            // This should never happen.
+            System.out.println("Interrupted while waiting for all tasks to complete.");
+            executor.shutdownNow();
+            exception.printStackTrace();
+            System.exit(0);
         }
+
 
         long finishTime = System.currentTimeMillis();
         System.out.println("Completed " + replays.size() + " task(s) in " + (int)(((finishTime - startTime) / 1000) / 60) + "m " + (int)(((finishTime - startTime) / 1000) % 60) + "s");

--- a/src/main/java/fr/rader/boblite/Main.java
+++ b/src/main/java/fr/rader/boblite/Main.java
@@ -89,6 +89,7 @@ public class Main {
         // we then show the edit menu
         Menu menu = new Menu();
         menu.show();
+
         // if the user doesn't want to edit their replay,
         // we stop bob
         if (!menu.wasGoPressed()) {
@@ -137,7 +138,8 @@ public class Main {
             try {
                 // Timeout doesn't really matter in this use case as we will want to wait for all tasks to complete before terminating.
                 isDone = executor.awaitTermination(7, TimeUnit.DAYS);
-            } catch (InterruptedException ex) { }
+            } catch (InterruptedException ex) {
+            }
         }
 
         long finishTime = System.currentTimeMillis();

--- a/src/main/java/fr/rader/boblite/ReplayData.java
+++ b/src/main/java/fr/rader/boblite/ReplayData.java
@@ -18,55 +18,21 @@ public class ReplayData {
     private Map<String, Object> metaData = new HashMap<>();
 
     private final ReplayZip replayZip;
-    private final File project;
+    private final File projectFolder;
     private final Main main;
 
     private File mcprFile;
 
-    public ReplayData(File project, Main main) {
-        this.project = project;
+    public ReplayData(File mcprFile, File projectFolder, Main main) throws NullPointerException {
+        if(mcprFile == null) throw new NullPointerException("The mcpr file cannot be null");
+        if(projectFolder == null) throw new NullPointerException("The project folder cannot be null");
+        if(main == null) throw new NullPointerException("main is null");
+
+        this.mcprFile = mcprFile;
+        this.projectFolder = projectFolder;
         this.main = main;
 
-        boolean alreadyHasReplay = false;
-
-        File[] projectFiles = project.listFiles();
-
-        if (projectFiles == null) {
-            System.out.println("'" + project.getAbsolutePath() + "' is not a valid path.");
-            System.exit(0);
-        }
-
-        for (File file : projectFiles) {
-            if (file.getName().endsWith(".mcpr")) {
-                alreadyHasReplay = true;
-                mcprFile = file;
-            }
-        }
-
-        if (!alreadyHasReplay) {
-            mcprFile = IO.openFilePrompt(OS.getMinecraftFolder() + "replay_recordings/", true, "Replay File", "mcpr");
-        }
-
-        if (mcprFile == null || mcprFile.isDirectory()) {
-            System.out.println("No Replay selected, stopping.");
-            System.exit(0);
-        }
-
-        if (!mcprFile.getName().endsWith("mcpr")) {
-            System.out.println("File is not a replay");
-            System.exit(0);
-        }
-
-        File oldMcprFile = new File(project.getAbsolutePath() + "/" + this.mcprFile.getName());
-        if (!alreadyHasReplay) {
-            try {
-                Files.copy(this.mcprFile.toPath(), oldMcprFile.toPath());
-            } catch (IOException ignored) {}
-
-            mcprFile = oldMcprFile;
-        }
-
-        replayZip = new ReplayZip(mcprFile);
+        this.replayZip = new ReplayZip(mcprFile);
         readMetaData();
         checkUnofficialReplays();
     }
@@ -101,10 +67,10 @@ public class ReplayData {
     }
 
     private void stopBob() {
-        JOptionPane.showMessageDialog(null, "Badlion/Lunar Replay detected, stopping Bob.\nPlease use the official ReplayMod.");
+        JOptionPane.showMessageDialog(null,  mcprFile.getName() + "\nBadlion/Lunar Replay detected, stopping Bob.\nPlease use the official ReplayMod.");
 
         // clear last opened project and delete files
-        main.getProjects().removeProject(project.getName());
+        main.getProjects().removeProject(main.getProjectName());
         main.getProjects().saveProjects();
 
         System.exit(0);

--- a/src/main/java/fr/rader/boblite/ReplayData.java
+++ b/src/main/java/fr/rader/boblite/ReplayData.java
@@ -24,15 +24,15 @@ public class ReplayData {
     private File mcprFile;
 
     public ReplayData(File mcprFile, File projectFolder, Main main) throws NullPointerException {
-        if(mcprFile == null) {
+        if (mcprFile == null) {
             throw new NullPointerException("The mcpr file cannot be null");
         }
 
-        if(projectFolder == null) {
+        if (projectFolder == null) {
             throw new NullPointerException("The project folder cannot be null");
         }
 
-        if(main == null) {
+        if (main == null) {
             throw new NullPointerException("main is null");
         }
 

--- a/src/main/java/fr/rader/boblite/ReplayData.java
+++ b/src/main/java/fr/rader/boblite/ReplayData.java
@@ -24,9 +24,15 @@ public class ReplayData {
     private File mcprFile;
 
     public ReplayData(File mcprFile, File projectFolder, Main main) throws NullPointerException {
-        if(mcprFile == null) throw new NullPointerException("The mcpr file cannot be null");
-        if(projectFolder == null) throw new NullPointerException("The project folder cannot be null");
-        if(main == null) throw new NullPointerException("main is null");
+        if(mcprFile == null){
+            throw new NullPointerException("The mcpr file cannot be null");
+        }
+        if(projectFolder == null){
+            throw new NullPointerException("The project folder cannot be null");
+        }
+        if(main == null){
+            throw new NullPointerException("main is null");
+        }
 
         this.mcprFile = mcprFile;
         this.projectFolder = projectFolder;

--- a/src/main/java/fr/rader/boblite/ReplayData.java
+++ b/src/main/java/fr/rader/boblite/ReplayData.java
@@ -2,14 +2,11 @@ package fr.rader.boblite;
 
 import com.google.gson.Gson;
 import fr.rader.boblite.utils.DataReader;
-import fr.rader.boblite.utils.IO;
-import fr.rader.boblite.utils.OS;
 import fr.rader.boblite.utils.ReplayZip;
 
 import javax.swing.*;
 import java.io.File;
 import java.io.IOException;
-import java.nio.file.Files;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -18,18 +15,13 @@ public class ReplayData {
     private Map<String, Object> metaData = new HashMap<>();
 
     private final ReplayZip replayZip;
-    private final File projectFolder;
+    private final File mcprFile;
+
     private final Main main;
 
-    private File mcprFile;
-
-    public ReplayData(File mcprFile, File projectFolder, Main main) throws NullPointerException {
+    public ReplayData(File mcprFile, Main main) throws NullPointerException {
         if (mcprFile == null) {
             throw new NullPointerException("The mcpr file cannot be null");
-        }
-
-        if (projectFolder == null) {
-            throw new NullPointerException("The project folder cannot be null");
         }
 
         if (main == null) {
@@ -37,7 +29,6 @@ public class ReplayData {
         }
 
         this.mcprFile = mcprFile;
-        this.projectFolder = projectFolder;
         this.main = main;
 
         this.replayZip = new ReplayZip(mcprFile);
@@ -82,10 +73,6 @@ public class ReplayData {
         main.getProjects().saveProjects();
 
         System.exit(0);
-    }
-
-    public File getMcprFile() {
-        return mcprFile;
     }
 
     public Object getMetaData(String key) {

--- a/src/main/java/fr/rader/boblite/ReplayData.java
+++ b/src/main/java/fr/rader/boblite/ReplayData.java
@@ -24,13 +24,15 @@ public class ReplayData {
     private File mcprFile;
 
     public ReplayData(File mcprFile, File projectFolder, Main main) throws NullPointerException {
-        if(mcprFile == null){
+        if(mcprFile == null) {
             throw new NullPointerException("The mcpr file cannot be null");
         }
-        if(projectFolder == null){
+
+        if(projectFolder == null) {
             throw new NullPointerException("The project folder cannot be null");
         }
-        if(main == null){
+
+        if(main == null) {
             throw new NullPointerException("main is null");
         }
 

--- a/src/main/java/fr/rader/boblite/utils/DataWriter.java
+++ b/src/main/java/fr/rader/boblite/utils/DataWriter.java
@@ -18,24 +18,13 @@ public class DataWriter {
 
     private int index = 0;
 
-    public DataWriter(boolean ignoreTempLocation) throws IOException {
-        if (!ignoreTempLocation) {
-            File file = IO.openFilePrompt(
-                    null,
-                    false,
-                    "Temporary file location",
-                    ""
-            );
+    public DataWriter(File tempFileDirectory) throws IOException {
+        this.tempFile = File.createTempFile(TEMP_FILE_NAME, null, tempFileDirectory.getAbsoluteFile());
+        this.outputStream = new FileOutputStream(tempFile);
+    }
 
-            if (file == null) {
-                System.exit(0);
-            }
-
-            this.tempFile = File.createTempFile(TEMP_FILE_NAME, null, file.getAbsoluteFile());
-        } else {
-            this.tempFile = File.createTempFile(TEMP_FILE_NAME, null);
-        }
-
+    public DataWriter() throws IOException {
+        this.tempFile = File.createTempFile(TEMP_FILE_NAME, null);
         this.outputStream = new FileOutputStream(tempFile);
     }
 

--- a/src/main/java/fr/rader/boblite/utils/IO.java
+++ b/src/main/java/fr/rader/boblite/utils/IO.java
@@ -17,37 +17,61 @@ public class IO {
      * @param path path to where the JFileChooser is opening to
      * @param description a description of the files we want
      * @param extensions a list of valid file extensions
+     * @return {@link File}[] - if the user selected a file or files and validated<br>
+     *         {@code null} - otherwise
+     */
+    public static File[] openFilePrompt(String path, String description, String... extensions) {
+        JFileChooser fileChooser = new JFileChooser(path);
+        // i don't know why this is here and i'm too scared to remove it
+        fileChooser.setAcceptAllFileFilterUsed(false);
+        // enable the ability to select multiple files
+        fileChooser.setMultiSelectionEnabled(true);
+
+        // set a file filter to only see files with the given extensions
+        fileChooser.setFileFilter(new ReplayFileFilter(description, extensions));
+
+        // show hidden files
+        fileChooser.setFileHidingEnabled(false);
+
+        // show the open file chooser to the user and wait for an answer
+        int option = fileChooser.showOpenDialog(null);
+
+        // if the user selected a file,
+        // we then return it
+        if (option == JFileChooser.APPROVE_OPTION) {
+            return fileChooser.getSelectedFiles();
+        }
+
+        // if they cancelled, we return false
+        return null;
+    }
+
+    /**
+     * Open a JFileChooser at the given path.
+     *
+     * @param path path to where the JFileChooser is opening to
      * @return {@link File} - if the user selected a file and validated<br>
      *         {@code null} - otherwise
      */
-    public static File openFilePrompt(String path, boolean isOpenDialog, String description, String... extensions) {
+    public static File saveFilePrompt(String path) {
         JFileChooser fileChooser = new JFileChooser(path);
         // i don't know why this is here and i'm too scared to remove it
         fileChooser.setAcceptAllFileFilterUsed(false);
         // disable the ability to select multiple files
         fileChooser.setMultiSelectionEnabled(false);
 
-        if (isOpenDialog) {
-            // set a file filter to only see files with the given extensions
-            fileChooser.setFileFilter(new ReplayFileFilter(description, extensions));
-        } else {
-            fileChooser.setFileSelectionMode(JFileChooser.DIRECTORIES_ONLY);
-        }
+        // only want directories for the save file prompt
+        fileChooser.setFileSelectionMode(JFileChooser.DIRECTORIES_ONLY);
 
         // show hidden files
         fileChooser.setFileHidingEnabled(false);
 
-        int option;
-        if (isOpenDialog) {
-            // show the file chooser to the user and wait for an answer
-            option = fileChooser.showOpenDialog(null);
-        } else {
-            option = fileChooser.showSaveDialog(null);
-        }
+        // show the save file chooser to the user and wait for an answer
+        int option = fileChooser.showSaveDialog(null);
 
         // if the user selected a file,
         // we then return it
-        if (option == JFileChooser.APPROVE_OPTION) {
+        if (option == JFileChooser.APPROVE_OPTION){
             return fileChooser.getSelectedFile();
         }
 
@@ -58,7 +82,7 @@ public class IO {
     public static void writeNBTFile(File destination, NBTCompound compound) {
         try {
             // create a data writer to write the compound to an input stream
-            DataWriter writer = new DataWriter(true);
+            DataWriter writer = new DataWriter();
 
             // write the compound to the data writer
             compound.writeNBT(writer);

--- a/src/main/java/fr/rader/boblite/utils/ReplayFileFilter.java
+++ b/src/main/java/fr/rader/boblite/utils/ReplayFileFilter.java
@@ -23,7 +23,7 @@ public class ReplayFileFilter extends FileFilter {
         for (String extension : extensions) {
             // check if the file is a file and
             // if it ends with a valid extension
-            if (!file.isDirectory() && file.getName().endsWith(extension)) {
+            if (file.isFile() && file.getName().endsWith(extension)) {
                 // if it does, it's accepted
                 return true;
             }


### PR DESCRIPTION
Allow the user to select and edit multiple replay files at once with the same settings. Each edit replay task is ran in its own thread, allowing for multiple replays to be edited in parallel.

One thing to note: Each replay being edited spawns it’s own progress bar. It might be a better user experience to have one progress bar/window for everything. However I figured it wasn’t worth the hassle to program one progress bar/window that updates from multiple threads so I left it as is.