### PR TITLE
Closing the inputstream from the writer so file can be deleted.

### DIFF
--- a/src/main/java/fr/rader/boblite/EditReplayTask.java
+++ b/src/main/java/fr/rader/boblite/EditReplayTask.java
@@ -9,6 +9,7 @@ import fr.rader.boblite.utils.ReplayZip;
 import javax.swing.*;
 import java.io.File;
 import java.io.IOException;
+import java.io.InputStream;
 
 public class EditReplayTask implements Runnable {
 
@@ -239,8 +240,10 @@ public class EditReplayTask implements Runnable {
 
             // we open the zip file, write the recording.tmcpr file and close the zip
             replayZip.open();
-            replayZip.addFile(writer.getInputStream(), "recording.tmcpr");
+            InputStream is = writer.getInputStream();
+            replayZip.addFile(is, "recording.tmcpr");
             replayZip.close();
+            is.close();
 
             writer.clear();
 

--- a/src/main/java/fr/rader/boblite/EditReplayTask.java
+++ b/src/main/java/fr/rader/boblite/EditReplayTask.java
@@ -240,10 +240,10 @@ public class EditReplayTask implements Runnable {
 
             // we open the zip file, write the recording.tmcpr file and close the zip
             replayZip.open();
-            InputStream is = writer.getInputStream();
-            replayZip.addFile(is, "recording.tmcpr");
+            InputStream inputStream = writer.getInputStream();
+            replayZip.addFile(inputStream, "recording.tmcpr");
             replayZip.close();
-            is.close();
+            inputStream.close();
 
             writer.clear();
 


### PR DESCRIPTION
The created inputstream from the writer in
```java
public InputStream getInputStream() throws IOException {
        flush();

        outputStream.close();

        return new FileInputStream(tempFile);
    }
```

was not closed in `EditReplayTask`. This fixes #4