### PR TITLE
Fix save dialogue on M1 mac

### DIFF
--- a/src/main/java/fr/rader/boblite/utils/IO.java
+++ b/src/main/java/fr/rader/boblite/utils/IO.java
@@ -67,7 +67,7 @@ public class IO {
         fileChooser.setFileHidingEnabled(false);
 
         // Save dialouge does not appear without sleeping for at least 2 ms on M1 mac?
-        try {Thread.sleep(2);} catch (InterruptedException e) {}
+        try {Thread.sleep(10);} catch (InterruptedException e) {}
 
         // show the save file chooser to the user and wait for an answer
         int option = fileChooser.showSaveDialog(null);

--- a/src/main/java/fr/rader/boblite/utils/IO.java
+++ b/src/main/java/fr/rader/boblite/utils/IO.java
@@ -66,6 +66,9 @@ public class IO {
         // show hidden files
         fileChooser.setFileHidingEnabled(false);
 
+        // Save dialouge does not appear without sleeping for at least 2 ms on M1 mac?
+        try {Thread.sleep(2);} catch (InterruptedException e) {}
+
         // show the save file chooser to the user and wait for an answer
         int option = fileChooser.showSaveDialog(null);
 


### PR DESCRIPTION
The save dialogue seems to not appear ( at least on my M1 mac ) without waiting at least 2 milliseconds for some strange reason. So before showing the save dialogue I added a sleep for 2 ms.